### PR TITLE
Release/0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2019-01-11
+### Fixed
+- Fix the way to get Method Name.
+
 ## [0.3.2] - 2019-01-11
 ### Added
 - Add StackTrace data in NCELFailToLog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.3.0] - 2019-01-09
+## [0.3.1] - 2019-01-09
 ### Added
 - Add LogConfig.DirectoryPath to change default path to log.
+### Removed
+- Remove StackSequence from Log.Error
 
 ## [0.2.2] - 2019-01-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.2] - 2019-01-11
+### Added
+- Add StackTrace data in NCELFailToLog.
+
 ## [0.3.1] - 2019-01-09
 ### Removed
 - Remove StackSequence from Log.Error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.3.1] - 2019-01-09
-### Added
-- Add LogConfig.DirectoryPath to change default path to log.
 ### Removed
 - Remove StackSequence from Log.Error
 ### Changed
 - Record layout when fail to record in default path.
+
+## [0.3.0] - 2019-01-09
+### Added
+- Add LogConfig.DirectoryPath to change default path to log.
 
 ## [0.2.2] - 2019-01-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - Add LogConfig.DirectoryPath to change default path to log.
 ### Removed
 - Remove StackSequence from Log.Error
+### Changed
+- Record layout when fail to record in default path.
 
 ## [0.2.2] - 2019-01-06
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- edit this value to change the current major.minor version -->
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(Prerelease)' != '' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- edit this value to change the current major.minor version -->
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(Prerelease)' != '' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- edit this value to change the current major.minor version -->
-    <VersionPrefix>0.3.2</VersionPrefix>
+    <VersionPrefix>0.3.3</VersionPrefix>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(Prerelease)' != '' ">

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ using ncel;
 and this is how to use in your code.
 ```bash
 Log.Information(string);
+Log.Error(string);
 ```
 
 ## Install

--- a/src/ncel/Utilities.cs
+++ b/src/ncel/Utilities.cs
@@ -37,7 +37,7 @@ namespace Ncel
                     local = $"{System.AppDomain.CurrentDomain.FriendlyName}|{previowsFrame}";
                     break;
                 case LogLevel.Error:
-                    local = $"{System.AppDomain.CurrentDomain.FriendlyName}|{previowsFrame}|{StackSequence}";
+                    local = $"{System.AppDomain.CurrentDomain.FriendlyName}|{previowsFrame}";
                     break;
                 default:
                     local = $"{System.AppDomain.CurrentDomain.FriendlyName}|{previowsFrame}|{StackSequence}";

--- a/src/ncel/Utilities.cs
+++ b/src/ncel/Utilities.cs
@@ -49,7 +49,7 @@ namespace Ncel
 
         public static void NCELFailToLog(Exception ex, string msgToLog)
         {
-            var id  = DateTime.Now.Ticks;
+            var id = DateTime.Now.Ticks;
             Console.WriteLine($"Fail to Log With current config, trying to log in this path:{DefaultLogFilePath}");
             DirectoryInfo diretoriolog = new DirectoryInfo(DefaultLogFilePath);
             if (!diretoriolog.Exists)
@@ -59,11 +59,35 @@ namespace Ncel
             var file = $"{diretoriolog}\\{System.AppDomain.CurrentDomain.FriendlyName}_{DateTime.Now.ToString("yyyy_MM_dd")}.log";
             using (StreamWriter sw = new StreamWriter(file))
             {
+                var name = Assembly.GetExecutingAssembly().GetName();
                 sw.WriteLine($"[{id}][{DateTime.Now}][Fail to record in]:'{DestinationPath()}'");
-                sw.WriteLine($"[{id}][Thrown:]{ex.GetType()}[Message:]{ex.Message}[Data:]{ex.Data}");
-                sw.WriteLine($"[{id}][msgToLog:]{msgToLog}");
+                sw.WriteLine($"[{id}][msgToLog]{msgToLog}");
+                sw.WriteLine($"[{id}][Exception-Thrown]{ex.GetType()}[Message]{ex.Message}[Data]{ex.Data}");
+
+
+                StackTrace stackTrace = new StackTrace(); // get call stack
+                StackFrame[] stackFrames = stackTrace.GetFrames();
+                var previowsFrame = stackFrames[1].GetMethod().Name;
+                for (int i = (stackFrames.Length - 1); i > 0; i--)
+                {
+                    var p = stackFrames[i].GetMethod().GetParameters();
+                    var sp = "";
+                    foreach (var item in p)
+                    {
+                        sp = $"{sp}{item.Name.ToString()},";
+                    }
+                    if (sp.EndsWith(","))
+                    {
+                        sp = sp.Remove(sp.Length - 1);
+                    }
+
+
+                    var msg = $"[{id}][pos:{i}][Class]{stackFrames[i].GetMethod().DeclaringType}[Method]{stackFrames[i].GetMethod().Name}({sp})";
+                    sw.WriteLine(msg);
+                }
+
             }
         }
-        private static readonly string DefaultLogFilePath = $"{System.IO.Path.GetTempPath()}\\NCELFailToLog";
+        private static readonly string DefaultLogFilePath = $"{System.IO.Path.GetTempPath()}NCELFailToLog";
     }
 }

--- a/src/ncel/Utilities.cs
+++ b/src/ncel/Utilities.cs
@@ -49,7 +49,8 @@ namespace Ncel
 
         public static void NCELFailToLog(Exception ex, string msgToLog)
         {
-            Console.WriteLine($"Fail to Log With current config, trying to log in this path{DefaultLogFilePath}");
+            var id  = DateTime.Now.Ticks;
+            Console.WriteLine($"Fail to Log With current config, trying to log in this path:{DefaultLogFilePath}");
             DirectoryInfo diretoriolog = new DirectoryInfo(DefaultLogFilePath);
             if (!diretoriolog.Exists)
             {
@@ -58,18 +59,9 @@ namespace Ncel
             var file = $"{diretoriolog}\\{System.AppDomain.CurrentDomain.FriendlyName}_{DateTime.Now.ToString("yyyy_MM_dd")}.log";
             using (StreamWriter sw = new StreamWriter(file))
             {
-                sw.WriteLine();
-                sw.WriteLine($"-------{DateTime.Now}-------");
-                sw.WriteLine($"---Fail to record in:{DestinationPath()}");
-                sw.WriteLine();
-                sw.WriteLine(msgToLog);
-                sw.WriteLine();
-                sw.WriteLine("--------------------------------");
-                sw.WriteLine();
-                sw.WriteLine(ex.Message);
-                sw.WriteLine();
-                sw.WriteLine("--------------------------------");
-                sw.WriteLine();
+                sw.WriteLine($"[{id}][{DateTime.Now}][Fail to record in]:'{DestinationPath()}'");
+                sw.WriteLine($"[{id}][Thrown:]{ex.GetType()}[Message:]{ex.Message}[Data:]{ex.Data}");
+                sw.WriteLine($"[{id}][msgToLog:]{msgToLog}");
             }
         }
         private static readonly string DefaultLogFilePath = $"{System.IO.Path.GetTempPath()}\\NCELFailToLog";

--- a/test/unitTest/LogTest.cs
+++ b/test/unitTest/LogTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Bogus;
@@ -71,13 +72,58 @@ namespace unitTest
         public void LogPath()
         {
             //Given
-            LogConfig.DirectoryPath = $"{Environment.CurrentDirectory}\\Logs\\{faker.System.DirectoryPath().Remove(0,1).Replace('/','\\')}";
+            var d = new DirectoryInfo($"{Environment.CurrentDirectory}\\LogPath");
+            if (d.Exists) d.Delete(true);
+            LogConfig.DirectoryPath = $"{d.FullName}\\{faker.System.DirectoryPath().Remove(0, 1).Replace('/', '\\')}";
             var x = new FileInfo(Utilities.DestinationPath());
             //When
             Log.Information($"{faker.Random.Number(1, 100)} Testando");
             System.Threading.Thread.Sleep(1000);
             //Then
             Assert.True(x.Exists);
+        }
+        [Fact]
+        public void MainWriterFailAlternativeLogGeneratesFile()
+        {
+            //Given
+            var d = new DirectoryInfo($"{System.IO.Path.GetTempPath()}\\NCELFailToLog");
+            if (d.Exists) d.Delete(true);
+            var e = new Exception();
+            var m = faker.Lorem.Words(5).ToList();
+            var n = new List<string>();
+            m.ForEach(c =>
+            {
+                n.Add(c + " ");
+            });
+            //When
+            Utilities.NCELFailToLog(e, string.Concat(n));
+            //Then
+            Assert.True(d.Exists);
+            Assert.True(d.GetFiles().Count() > 0);
+        }
+        [Fact]
+        public void MainWriterFailAlternativeProperInformationInfile()
+        {
+            //Given
+            var d = new DirectoryInfo($"{System.IO.Path.GetTempPath()}\\NCELFailToLog");
+            if (d.Exists) d.Delete(true);
+            var e = new Exception();
+            var m = faker.Lorem.Words(5).ToList();
+            var n = new List<string>();
+            m.ForEach(c =>
+            {
+                n.Add(c + " ");
+            });
+            //When
+            Utilities.NCELFailToLog(e, string.Concat(n));
+            //Then
+            var arquivos = d.GetFiles();
+            var ret = "";
+            foreach (var item in arquivos)
+            {
+                ret = ret + File.ReadAllText(item.FullName);
+            }
+            Assert.Contains(string.Concat(n), ret);
         }
 
     }

--- a/test/unitTest/LogTest.cs
+++ b/test/unitTest/LogTest.cs
@@ -125,6 +125,5 @@ namespace unitTest
             }
             Assert.Contains(string.Concat(n), ret);
         }
-
     }
 }

--- a/test/unitTest/LogTest.cs
+++ b/test/unitTest/LogTest.cs
@@ -88,7 +88,7 @@ namespace unitTest
             //Given
             var d = new DirectoryInfo($"{System.IO.Path.GetTempPath()}\\NCELFailToLog");
             if (d.Exists) d.Delete(true);
-            var e = new Exception();
+            var e = faker.System.Exception();
             var m = faker.Lorem.Words(5).ToList();
             var n = new List<string>();
             m.ForEach(c =>
@@ -107,7 +107,7 @@ namespace unitTest
             //Given
             var d = new DirectoryInfo($"{System.IO.Path.GetTempPath()}\\NCELFailToLog");
             if (d.Exists) d.Delete(true);
-            var e = new Exception();
+            var e = faker.System.Exception();
             var m = faker.Lorem.Words(5).ToList();
             var n = new List<string>();
             m.ForEach(c =>


### PR DESCRIPTION
## [0.3.2] - 2019-01-11
### Added
- Add StackTrace data in NCELFailToLog.

## [0.3.1] - 2019-01-09
### Removed
- Remove StackSequence from Log.Error
### Changed
- Record layout when fail to record in default path.

## [0.3.0] - 2019-01-09
### Added
- Add LogConfig.DirectoryPath to change default path to log.